### PR TITLE
Make lexer faster, Allocate to make borrow checker happy on parser

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::io::prelude::*;
 use std::time::{Duration, Instant};
+use crate::risp::Token;
 
 mod risp;
 
@@ -73,12 +74,12 @@ fn lex_speed() {
     
     let bench_fn = || {
         let mut lexer = risp::Lexer::new(src);
-        while !matches!(lexer.next(), Ok(risp::Token::EOF)) {
+        while !matches!(lexer.next(), Ok(Token { kind: risp::Kind::EOF, .. })) {
             /* Benchmark */
         }
     };
 
-    let avg = bench(bench_fn, 5_000, 100);
+    let avg = bench(bench_fn, 500_000, 100);
     
     let bytes_per_sec = (1_000_000_000.0 / avg.as_nanos() as f64) * src.len() as f64;
     let mb  = 1000.0 * 1000.0;
@@ -87,6 +88,8 @@ fn lex_speed() {
 }
 
 fn main() {
+    // TODO: Change this and everything else to how you'd like it
+    // This averages to around ~395 MBps for me, on an i7 6500U running windows
     lex_speed();
     repl();
 }

--- a/src/risp/interpreter.rs
+++ b/src/risp/interpreter.rs
@@ -1,15 +1,14 @@
 use crate::risp::{AstNode, Type, Error};
 use crate::risp::rispstd;
 
-pub struct Intepreter {
-}
+pub struct Intepreter { }
 
 impl Intepreter {
     /// Create a new interpreter
     // This will be useful when interpreter will have default arguments
     // eg. symbol table
     pub fn new() -> Self {
-        Intepreter {}
+        Intepreter { }
     }
 
     /// Gets the value associated with a name from the interpreter's 'symbol table'
@@ -17,14 +16,14 @@ impl Intepreter {
         if name == "println" {
             Ok(Type::BuiltinFn(&rispstd::println))
         } else {
-            Err(Error::NameError(name))
+            Err(Error::NameError(name.to_owned()))
         }
     }
 
     /// Evaluates an AST node
     pub fn eval(&self, node: AstNode) -> Result<Type, Error> {
         match node {
-            AstNode::Name(name) => self.get_name(name),
+            AstNode::Name(name) => self.get_name(name.to_owned()),
 
             AstNode::Number(num) => Ok(Type::Number(num)),
             

--- a/src/risp/lexer.rs
+++ b/src/risp/lexer.rs
@@ -1,34 +1,38 @@
-use crate::risp::{Error, Token};
+use crate::risp::{ Error, Kind, Token };
+use crate::risp::utils::Span;
 use std::str::Chars;
 
 /// Struct that represents a lexer, used for producing tokens from a string of text
 pub struct Lexer<'a> {
-    chars: Chars<'a>, // Iterator over the characters of the text
+    /// Iterator over the characters of the text
+    chars : Chars<'a>,
+    /// Current position that the lexer references to generate tokens
+    pos   : usize,
 }
 
 impl<'a> Lexer<'a> {
     /// Creates a new lexer
     pub fn new(text: &'a str) -> Self {
         Self {
-            chars: text.chars(),
+            chars : text.chars(),
+            pos   : 0,
         }
     }
 
     /// Takes characters from the lexer while a predicate is met
-    fn take_while(&mut self, mut predicate: impl FnMut(char) -> bool) -> String {
-        let mut taken = String::new();
-
+    #[inline]
+    fn take_while(&mut self, mut predicate: impl FnMut(char) -> bool) -> Span {
         loop {
             // Character iterator is cloned for better performance
             let mut clone = self.chars.clone();
-
+            let start = self.pos;
             match clone.next() {
                 Some(c) if predicate(c) => {
-                    taken.push(c);
                     self.chars = clone;
+                    self.pos  += c.len_utf8();
                 }
 
-                _ => return taken,
+                _ => return Span::new(start, self.pos),
             }
         }
     }
@@ -36,53 +40,61 @@ impl<'a> Lexer<'a> {
     /// Advances the lexer to the next character
     #[inline]
     fn adv(&mut self) {
-        self.chars.next();
-    }
-
-    /// Returns the current character
-    #[inline]
-    fn current_char(&self) -> Option<char> {
-        self.chars.clone().next()
+        self.pos +=
+            match self.chars.next() {
+                Some(c) => c,
+                None => return,
+            }
+                .len_utf8();
     }
 
     /// Gets the next token from the text and returns it
+    #[inline]
     pub fn next(&mut self) -> Result<Token, Error> {
-        match self.current_char().unwrap_or('\0') {
-            
-            '\0' => {
-                if self.current_char() == None {
-                    Ok(Token::EOF)
-                } else {
-                    Err(Error::LexError('\0'))
-                }
-            },
-            
+        let start = self.pos;
+        let next =
+            self
+                .chars
+                .clone()
+                .next();
+        let next = match next {
+            None => {
+                return Ok(Token {
+                    kind : Kind::EOF,
+                    span : Span::new(self.pos, self.pos)
+                })
+            }
+            Some(c) => c
+        };
+        match next {
             // Skip character if it is whitespace
             c if c.is_whitespace() => {
                 self.take_while(|c| c.is_whitespace());
                 self.next()
-
             }
 
-            c if c.is_numeric() => {
-                let value = self.take_while(|c| c.is_numeric());
-                Ok(Token::Number(value.parse().unwrap()))
-            
-            } 
+            // Todo: Use a proper number parser here
+            '0'..='9' => {
+                let span = self.take_while(|c| matches!(c, '0'..='9'));
+                Ok(Token { span, kind: Kind::Number })
+            }
 
-            c if c.is_alphabetic() => {
-                let value = self.take_while(|c| c.is_alphabetic());
-                Ok(Token::Name(value))
-
+            // Change this to your liking
+            // Currently matches anything like: abdc_01, __99, _0_9_a, abc, _ etc.
+            'a'..='z' | 'A'..='Z' | '_' => {
+                let span =
+                    self.take_while(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9'));
+                Ok(Token { span, kind: Kind::Name })
             }
             
             // Miscellaneous single-character tokens
             c => {
                 self.adv();
+                let span = Span::new(start, self.pos);
                 match c {
-                    '(' => Ok(Token::OpenParen),
-                    ')' => Ok(Token::CloseParen),
-                    _ => Err(Error::LexError(c)),
+                    '(' => Ok(Token { span, kind: Kind::OpenParen }),
+                    ')' => Ok(Token { span, kind: Kind::CloseParen }),
+                    _   => Err(Error::LexError(c)),
                 }
             }
         }

--- a/src/risp/parser.rs
+++ b/src/risp/parser.rs
@@ -1,4 +1,4 @@
-use crate::risp::{Token, AstNode, Lexer, Error};
+use crate::risp::{ Token, Kind, AstNode, Lexer, Error };
 
 /// Checks if Enum variants are equal, without comparing the values
 fn variant_eq<T>(a: &T, b: &T) -> bool {
@@ -7,16 +7,18 @@ fn variant_eq<T>(a: &T, b: &T) -> bool {
 
 /// Struct which represents a parser, that parses tokens into ASTs
 pub struct Parser<'a> {
-    lexer: Lexer<'a>,
-    current_token: Token
+    lexer         : Lexer<'a>,
+    current_token : Token,
+    src           : &'a str,
 }
 
 impl<'a> Parser<'a> {
     /// Create a new parser.
-    pub fn new(mut lexer: Lexer<'a>) -> Result<Self, Error> {
+    pub fn new(mut lexer: Lexer<'a>, src: &'a str) -> Result<Self, Error> {
         Ok(Self {
-            current_token: lexer.next()?,
-            lexer
+            current_token : lexer.next()?,
+            src,
+            lexer,
         })
     }
 
@@ -28,8 +30,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Checks if current token is of a specific type, and then advances the parser
-    fn expect(&mut self, kind: Token) -> Result<(), Error> {
-        if !variant_eq(&self.current_token, &kind) {
+    fn expect(&mut self, kind: Kind) -> Result<(), Error> {
+        if !variant_eq(&self.current_token.kind, &kind) {
             return Err(Error::ExpectError(kind))
         }
         self.advance()
@@ -38,12 +40,13 @@ impl<'a> Parser<'a> {
     /// Parses an atom
     /// ATOM ::= EXPR | NUMBER | NAME
     fn parse_atom(&mut self) -> Result<AstNode, Error> {
-        let node = match &self.current_token {
-
-            Token::Number(value) => AstNode::Number(*value),
-            Token::Name(value) => AstNode::Name(value.clone()),
-                        
-            Token::EOF => return Err(Error::EOFError("atom".to_owned())),
+        let node = match &self.current_token.kind {
+            Kind::Number =>
+            // TODO: Do not use unwrap
+                AstNode::Number((&self.src[self.current_token.span.range()]).parse().unwrap()),
+            // TODO: Somehow get the borrow checker to agree with using `&str` here for better performance
+            Kind::Name   => AstNode::Name(self.src[self.current_token.span.range()].to_owned()),
+            Kind::EOF    => return Err(Error::EOFError("atom".to_owned())),
             t => return Err(Error::Error(format!("Invalid token {t:?} in atom")))
         };
         self.advance()?;
@@ -53,28 +56,26 @@ impl<'a> Parser<'a> {
     /// Parses a list
     /// LIST ::= '(' EXPR* ')'
     fn parse_list(&mut self) -> Result<Vec<AstNode>, Error> {
-        self.expect(Token::OpenParen)?;
-        
+        self.expect(Kind::OpenParen)?;
+
         let mut elements: Vec<AstNode> = Vec::new();
 
-        while self.current_token != Token::CloseParen && self.current_token != Token::EOF {
+        while self.current_token.kind != Kind::CloseParen && self.current_token.kind != Kind::EOF {
             elements.push(self.parse_expr()?);
         }
 
-        self.expect(Token::CloseParen)?;
+        self.expect(Kind::CloseParen)?;
         return Ok(elements);
     }
 
     /// Parses an expression
     /// EXPR ::= LIST | ATOM
     pub fn parse_expr(&mut self) -> Result<AstNode, Error> {
-        
-        match self.current_token {
-            Token::OpenParen => Ok(AstNode::Expr(self.parse_list()?)),
 
-            Token::EOF => return Err(Error::EOFError("expr".to_owned())),
-
-            _ => self.parse_atom()
+        match self.current_token.kind {
+            Kind::OpenParen => Ok(AstNode::Expr(self.parse_list()?)),
+            Kind::EOF       => return Err(Error::EOFError("expr".to_owned())),
+            _               => self.parse_atom(),
         }
     }
 }

--- a/src/risp/utils.rs
+++ b/src/risp/utils.rs
@@ -1,0 +1,21 @@
+/// A simple span of lines, or a start and end position
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Span {
+    /// The start location that the span references in the source
+    pub start : usize,
+    /// The end location that the span references in the source
+    pub end   : usize,
+}
+
+impl Span {
+    /// Create a new span
+    pub fn new(start: usize, end: usize) -> Self  {
+        Self { start, end }
+    }
+
+    /// Convert the span to a [`Range<usize>`](core::ops::Range)
+    #[inline]
+    pub fn range(&self) -> std::ops::Range<usize> {
+        self.start..self.end
+    }
+}


### PR DESCRIPTION
I just had to do this.

Change it up however you'd like
The lexer now lexes at ~395 MBps with some processes running in the background on my PC
Check if it contains any bugs
I did not try to change the overall code, but changed everything enough to make the borrow checker happy
Including the fact that I had to allocate a string in the parser :( (you could store values as spans in the parser to overcome this, probably)
The changes could be enough to introduce bugs in other parts of your code, so change it however you wish